### PR TITLE
[결제] - 결제 요청 시, json body가 아닌 객체를 보내도록 변경함

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,21 +45,19 @@
         </dependency>
 
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20231013</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/com.googlecode.json-simple/json-simple -->
-        <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>1.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>

--- a/src/main/java/com/nhnacademy/frontserver1/application/service/OrderService.java
+++ b/src/main/java/com/nhnacademy/frontserver1/application/service/OrderService.java
@@ -2,8 +2,15 @@ package com.nhnacademy.frontserver1.application.service;
 
 import com.nhnacademy.frontserver1.presentation.dto.request.order.CreateOrderRequest;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.CreateOrderResponse;
+import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadShippingPolicyResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderService {
 
     CreateOrderResponse createPreOrder(CreateOrderRequest request, Long userId);
+
+    ReadShippingPolicyResponse findAllOrderPolicy(Pageable pageable, Integer totalAmount);
+
+    ReadShippingPolicyResponse findFreePolicy();
 }

--- a/src/main/java/com/nhnacademy/frontserver1/application/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/nhnacademy/frontserver1/application/service/impl/OrderServiceImpl.java
@@ -3,9 +3,14 @@ package com.nhnacademy.frontserver1.application.service.impl;
 import com.nhnacademy.frontserver1.application.service.OrderService;
 import com.nhnacademy.frontserver1.application.service.dto.request.CreatePreOrderRequest;
 import com.nhnacademy.frontserver1.infrastructure.adaptor.OrderAdaptor;
+import com.nhnacademy.frontserver1.infrastructure.adaptor.PolicyAdaptor;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.CreateOrderRequest;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.CreateOrderResponse;
+import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadShippingPolicyResponse;
+import java.util.Comparator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,11 +18,28 @@ import org.springframework.stereotype.Service;
 public class OrderServiceImpl implements OrderService {
 
     private final OrderAdaptor orderAdaptor;
+    private final PolicyAdaptor policyAdaptor;
 
     @Override
     public CreateOrderResponse createPreOrder(CreateOrderRequest request, Long userId) {
         CreatePreOrderRequest preOrderRequest = request.toPreOrderRequest(userId);
 
         return orderAdaptor.createPreOrder(preOrderRequest);
+    }
+
+    @Override
+    public ReadShippingPolicyResponse findAllOrderPolicy(Pageable pageable,
+        Integer totalAmount) {
+        Page<ReadShippingPolicyResponse> policyResponses = policyAdaptor.findAllDeliveryPolicy(pageable).body();
+
+        return policyResponses.getContent().stream()
+            .filter(policy -> totalAmount >= policy.shippingPolicyMinAmount())
+            .min(Comparator.comparingInt(ReadShippingPolicyResponse::shippingPolicyFee))
+            .orElse(null);
+    }
+
+    @Override
+    public ReadShippingPolicyResponse findFreePolicy() {
+        return policyAdaptor.findFreePolicy().body();
     }
 }

--- a/src/main/java/com/nhnacademy/frontserver1/application/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/nhnacademy/frontserver1/application/service/impl/PaymentServiceImpl.java
@@ -17,17 +17,9 @@ public class PaymentServiceImpl implements PaymentService {
 
     private final PaymentAdaptor paymentAdaptor;
 
-    // todo. 요청을 dto로 받도록 수정
     @Override
     public CreatePaymentResponse createPayment(CreatePaymentRequest request) {
-
-        try {
-            String requestBody = new ObjectMapper().writeValueAsString(request);
-
-            return paymentAdaptor.createPayment(requestBody);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        return paymentAdaptor.createPayment(request);
     }
 
 }

--- a/src/main/java/com/nhnacademy/frontserver1/infrastructure/adaptor/PaymentAdaptor.java
+++ b/src/main/java/com/nhnacademy/frontserver1/infrastructure/adaptor/PaymentAdaptor.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.frontserver1.infrastructure.adaptor;
 
+import com.nhnacademy.frontserver1.presentation.dto.request.payment.CreatePaymentRequest;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.CreatePaymentResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,5 +10,5 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface PaymentAdaptor {
 
     @PostMapping("/confirm")
-    CreatePaymentResponse createPayment(@RequestBody String request);
+    CreatePaymentResponse createPayment(@RequestBody CreatePaymentRequest request);
 }

--- a/src/main/java/com/nhnacademy/frontserver1/infrastructure/adaptor/PolicyAdaptor.java
+++ b/src/main/java/com/nhnacademy/frontserver1/infrastructure/adaptor/PolicyAdaptor.java
@@ -1,0 +1,18 @@
+package com.nhnacademy.frontserver1.infrastructure.adaptor;
+
+import com.nhnacademy.frontserver1.presentation.dto.response.ApiResponse;
+import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadShippingPolicyResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "policyAdaptor", url = "http://localhost:8081/policies")
+public interface PolicyAdaptor {
+
+    @GetMapping("/shipping")
+    ApiResponse<Page<ReadShippingPolicyResponse>> findAllDeliveryPolicy(Pageable pageable);
+
+    @GetMapping("/shipping/free")
+    ApiResponse<ReadShippingPolicyResponse> findFreePolicy();
+}

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/controller/OrderController.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/controller/OrderController.java
@@ -1,21 +1,23 @@
 package com.nhnacademy.frontserver1.presentation.controller;
 
 import com.nhnacademy.frontserver1.application.service.OrderService;
-import com.nhnacademy.frontserver1.presentation.dto.request.order.FindProductRequest;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.CreateOrderRequest;
+import com.nhnacademy.frontserver1.presentation.dto.request.order.FindProductRequest;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.CreateOrderResponse;
+import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadShippingPolicyResponse;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequestMapping("/orders")
@@ -26,14 +28,31 @@ public class OrderController {
     private final OrderService orderService;
 
     @GetMapping("checkout")
-    public String checkout(Model model) {
+    public String checkout(Model model, Pageable pageable) {
         List<FindProductRequest> requests = new ArrayList<>();
-        requests.add(new FindProductRequest(1L, 2, BigDecimal.valueOf(10000)));
-        requests.add(new FindProductRequest(2L, 5, BigDecimal.valueOf(50000)));
+        requests.add(new FindProductRequest(1L, 1, BigDecimal.valueOf(1000)));
+        requests.add(new FindProductRequest(2L, 5, BigDecimal.valueOf(5000)));
 
+        Integer totalAmount = getTotalAmount(requests);
+        ReadShippingPolicyResponse shippingPolicy = orderService.findAllOrderPolicy(pageable, totalAmount);
+        ReadShippingPolicyResponse freeShippingPolicy = orderService.findFreePolicy();
+        Integer freeShippingAmount = freeShippingPolicy.shippingPolicyMinAmount() - totalAmount;
+
+        model.addAttribute("shippingPolicy", shippingPolicy);
+        model.addAttribute("freeShippingPolicy", freeShippingPolicy);
+        model.addAttribute("freeShippingAmount", freeShippingAmount);
+        model.addAttribute("totalAmount", totalAmount);
         model.addAttribute("requests", requests);
 
         return "order/checkout";
+    }
+
+    private Integer getTotalAmount(List<FindProductRequest> requests) {
+        BigDecimal totalAmount = requests.stream()
+            .map(request -> request.price().multiply(BigDecimal.valueOf(request.quantity())))
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return totalAmount.intValue();
     }
 
     @PostMapping
@@ -42,7 +61,7 @@ public class OrderController {
         Long userId = 1L;
         CreateOrderResponse response = orderService.createPreOrder(request, userId);
 
-        return "redirect:/payments/" + request.orderId();
+        return "redirect:/payments/" + response.orderId();
     }
 
 }

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/controller/PaymentController.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/controller/PaymentController.java
@@ -27,13 +27,11 @@ public class PaymentController {
 
     @PostMapping("confirm")
     public String confirm(@RequestBody CreatePaymentRequest request) {
-        try {
-            paymentService.createPayment(request);
-        } catch (Exception e) {
-            return "order/fail";
+        if (paymentService.createPayment(request).status() == 200) {
+            return "order/success";
         }
 
-        return "order/success";
+        return "order/fail";
     }
 
     @GetMapping("success")

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/dto/response/ApiResponse.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/dto/response/ApiResponse.java
@@ -1,0 +1,4 @@
+package com.nhnacademy.frontserver1.presentation.dto.response;
+
+public record ApiResponse<T> (T body, int status) {
+}

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/dto/response/order/CreatePaymentResponse.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/dto/response/order/CreatePaymentResponse.java
@@ -1,7 +1,5 @@
 package com.nhnacademy.frontserver1.presentation.dto.response.order;
 
-import java.math.BigDecimal;
-
-public record CreatePaymentResponse(String orderId, BigDecimal amount) {
+public record CreatePaymentResponse(int status) {
 
 }

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/dto/response/order/ReadShippingPolicyResponse.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/dto/response/order/ReadShippingPolicyResponse.java
@@ -1,0 +1,7 @@
+package com.nhnacademy.frontserver1.presentation.dto.response.order;
+
+public record ReadShippingPolicyResponse(Long shippingPolicyId,
+                                         Integer shippingPolicyFee,
+                                         Integer shippingPolicyMinAmount) {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,8 @@ server:
 spring:
   application:
     name: front-server-1
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://133.186.241.167:3306/be6_yes255_book
+    username: be6_yes255
+    password: ${YES25_5_MYSQL_PASSWORD}

--- a/src/main/resources/templates/order/checkout.html
+++ b/src/main/resources/templates/order/checkout.html
@@ -520,28 +520,25 @@
 
                     <div class="col-md-12">
                       <div class="checkout-payment-option">
-                        <h6 class="heading-6 font-weight-400 payment-title">Select Delivery
-                          Option</h6>
+                        <h6 class="heading-6 font-weight-400 payment-title">배송비 정책</h6>
                         <div class="payment-option-wrapper">
                           <div class="single-payment-option">
-                            <input type="radio" name="shipping" checked id="shipping-1">
-                            <label for="shipping-1">
+                            <input type="radio" name="shipping"
+                                   th:id="'shipping-' + ${shippingPolicy.shippingPolicyId}"
+                                   th:value="${shippingPolicy.shippingPolicyFee}"
+                                   checked readonly>
+                            <label th:for="'shipping-' + ${shippingPolicy.shippingPolicyId}">
                               <img src="https://via.placeholder.com/60x32" alt="Shipping">
-                              <p>Standard Shipping</p>
-                              <span class="price">$10.50</span>
-                            </label>
-                          </div>
-                          <div class="single-payment-option">
-                            <input type="radio" name="shipping" id="shipping-2">
-                            <label for="shipping-2">
-                              <img src="https://via.placeholder.com/60x32" alt="Shipping">
-                              <p>Standard Shipping</p>
-                              <span class="price">$10.50</span>
+                              <span class="price"
+                                    th:text="${'배송비 ' + shippingPolicy.shippingPolicyFee + '원'}"></span>
+                              <p class="min-amount"
+                                 th:text="'최소 주문 금액 ' + ${shippingPolicy.shippingPolicyMinAmount} + '원'"></p>
                             </label>
                           </div>
                         </div>
                       </div>
                     </div>
+
                   </form>
                 </div>
               </section>
@@ -551,42 +548,33 @@
       </div>
       <div class="col-lg-4">
         <div class="checkout-sidebar">
-<!--          <div class="checkout-sidebar-coupon">-->
-<!--            <p>Appy Coupon to get discount!</p>-->
-<!--            <form action="#">-->
-<!--              <div class="single-form form-default">-->
-<!--                <div class="form-input form">-->
-<!--                  <input type="text" placeholder="Coupon Code">-->
-<!--                </div>-->
-<!--                <div class="button">-->
-<!--                  <button class="btn">apply</button>-->
-<!--                </div>-->
-<!--              </div>-->
-<!--            </form>-->
-<!--          </div>-->
           <button onclick="openCouponPopup()">쿠폰 목록 보기</button>
           <input type="text" id="selectedCoupon" readonly>
+          <input type="hidden" id="couponDiscount" value="0">
           <div class="checkout-sidebar-price-table mt-30">
             <h5 class="title">Pricing Table</h5>
             <div class="sub-total-price">
               <div class="total-price">
-                <p class="value">Subtotal Price:</p>
-                <p class="price">$144.00</p>
+                <p class="value">상품 금액:</p>
+                <p class="price" th:text="${totalAmount + '원'}" id="totalAmount"></p>
               </div>
               <div class="total-price shipping">
-                <p class="value">Shipping Price:</p>
-                <p class="price">$10.50</p>
+                <p class="value">배송비:</p>
+                <p class="price" id="shippingFee">0원</p>
               </div>
               <div class="total-price discount">
-                <p class="value">Discount:</p>
-                <p class="price">$10.00</p>
+                <p class="value">할인:</p>
+                <p class="price" id="discountAmount">0원</p>
+              </div>
+              <div class="additional-info mt-30 progress-bar" th:if="${freeShippingAmount != null && freeShippingAmount > 0}">
+                <p th:text="'무료 배송까지 ' + ${freeShippingAmount} + '원'"></p>
               </div>
             </div>
 
             <div class="total-payable">
               <div class="payable-price">
-                <p class="value">Total Price:</p>
-                <p class="price" id="totalPriceValue">$164.50</p>
+                <p class="value">총 금액:</p>
+                <p class="price" id="totalPriceValue">0원</p>
               </div>
             </div>
             <div class="price-table-btn button">
@@ -827,7 +815,8 @@
     document.getElementById('hiddenOrderEmail').value = document.getElementById('orderEmail').value;
     document.getElementById('hiddenOrderPhoneNumber').value = document.getElementById(
         'orderPhoneNumber').value;
-    document.getElementById('hiddenReceiveOrderName').value = document.getElementById('receiveName').value;
+    document.getElementById('hiddenReceiveOrderName').value = document.getElementById(
+        'receiveName').value;
     document.getElementById('hiddenReceiveOrderEmail').value = document.getElementById(
         'receiveEmail').value;
     document.getElementById('hiddenReceiveOrderPhoneNumber').value = document.getElementById(
@@ -838,19 +827,43 @@
     document.getElementById('hiddenTakeoutType').value = document.getElementById(
         'takeoutType').value;
 
-    document.getElementById('hiddenTotalPrice').value = totalPrice.replace('$', '').trim();
+    document.getElementById('hiddenTotalPrice').value = totalPrice.replace('원', '').trim();
 
     document.getElementById('orderForm').submit();
   }
 
   function openCouponPopup() {
     const popup = window.open('couponPopup.html', '쿠폰 목록', 'width=600,height=400');
-    popup.onunload = function() {
+    popup.onunload = function () {
       if (popup.selectedCoupon) {
         document.getElementById('selectedCoupon').value = popup.selectedCoupon;
       }
     };
   }
+
+  function updateShippingFee(fee) {
+    document.getElementById('shippingFee').innerText = fee + '원';
+    updateTotalPrice();
+  }
+
+  function updateTotalPrice() {
+    const totalAmount = parseInt(document.getElementById('totalAmount').innerText.replace('원', ''));
+    const shippingFee = parseInt(document.getElementById('shippingFee').innerText.replace('원', ''));
+    const discountAmount = parseInt(document.getElementById('couponDiscount').value, 10);
+    const totalPrice = totalAmount + shippingFee - discountAmount;
+    document.getElementById('discountAmount').innerText = discountAmount + '원';
+    document.getElementById('totalPriceValue').innerText = totalPrice + '원';
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const firstShippingOption = document.querySelector('input[name="shipping"]:checked');
+    if (firstShippingOption) {
+      updateShippingFee(firstShippingOption.value);
+    } else {
+      updateTotalPrice();
+    }
+  });
+
 </script>
 </body>
 

--- a/src/test/java/com/nhnacademy/frontserver1/FrontServer1ApplicationTests.java
+++ b/src/test/java/com/nhnacademy/frontserver1/FrontServer1ApplicationTests.java
@@ -2,8 +2,10 @@ package com.nhnacademy.frontserver1;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class FrontServer1ApplicationTests {
 
     @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: password


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [ ] Feature
- [ ] Rename
- [ ] Test
- [x] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 결제 요청 시, json body가 아닌 객체를 보내도록 변경하였습니다.
- 응답으로 200이 오면 성공 페이지로, 아니면 에러 페이지로 리디렉션합니다.
- 추후 성공과 에러 페이지는 와이어 프레임에 작성한대로 변경할 예정입니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [x] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->
![image](https://github.com/nhnacademy-be6-yes-25-5/yes-25-5-front-server/assets/105257665/0270fb3c-89e1-4030-8cea-322ad931a166)
