### PR TITLE
[주문] - 주문 실패 시, 주문 실패 페이지를 보여주도록 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ COPY . .
 RUN mvn package
 
 # Default command
+# prod 설정 추가
 CMD ["java", "-jar", "target/FrontServer1-0.0.1-SNAPSHOT.jar", "--spring.profiles.active=prod"]

--- a/src/main/java/com/nhnacademy/frontserver1/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/nhnacademy/frontserver1/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.nhnacademy.frontserver1.common.handler;
+
+
+import com.nhnacademy.frontserver1.common.exception.FeignClientException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(FeignClientException.class)
+    public String handleFeignClientException(FeignClientException e, Model model) {
+        log.error("error :", e);
+
+        return "404";
+    }
+}

--- a/src/main/java/com/nhnacademy/frontserver1/infrastructure/filter/AuthenticationFilter.java
+++ b/src/main/java/com/nhnacademy/frontserver1/infrastructure/filter/AuthenticationFilter.java
@@ -19,10 +19,10 @@ import java.io.IOException;
  * @author lettuce82
  * @version 1.0
  */
-@Component
+//@Component
 public class AuthenticationFilter extends OncePerRequestFilter {
 
-    @Autowired
+//    @Autowired
     private TokenService tokenService;
 
     private static final String[] RESOURCE_PATTERNS = {

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/controller/OrderController.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/controller/OrderController.java
@@ -71,4 +71,9 @@ public class OrderController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/fail")
+    public String getErrorPage() {
+        return "error/order-fail";
+    }
+
 }

--- a/src/main/resources/templates/error/order-fail.html
+++ b/src/main/resources/templates/error/order-fail.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html class="no-js" lang="ko">
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="x-ua-compatible" content="ie=edge" />
+  <title>주문 실패 - ShopGrids Bootstrap 5 eCommerce HTML Template</title>
+  <meta name="description" content="" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/images/favicon.svg">
+
+  <!-- ========================= CSS here ========================= -->
+  <link rel="stylesheet" href="/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/css/LineIcons.3.0.css">
+  <link rel="stylesheet" href="/css/main.css">
+
+</head>
+
+<body>
+<!--[if lte IE 9]>
+<p class="browserupgrade">
+  You are using an <strong>outdated</strong> browser. Please
+  <a href="https://browsehappy.com/">upgrade your browser</a> to improve
+  your experience and security.
+</p>
+<![endif]-->
+
+<!-- Preloader -->
+<div class="preloader">
+  <div class="preloader-inner">
+    <div class="preloader-icon">
+      <span></span>
+      <span></span>
+    </div>
+  </div>
+</div>
+<!-- /End Preloader -->
+
+<!-- Start Error Area -->
+<div class="error-area">
+  <div class="d-table">
+    <div class="d-table-cell">
+      <div class="container">
+        <div class="error-content">
+          <h1>주문 실패</h1>
+          <h2>주문을 처리하던 도중 문제가 발생했습니다.</h2>
+          <p>죄송합니다. 주문을 처리할 수 없습니다. 나중에 다시 시도하거나 고객 센터에 문의해 주세요.</p>
+          <div class="button">
+            <a href="/" class="btn">홈으로 돌아가기</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- End Error Area -->
+
+<!-- ========================= JS here ========================= -->
+<script src="/js/bootstrap.min.js"></script>
+<script>
+  window.onload = function () {
+    window.setTimeout(fadeout, 500);
+  }
+
+  function fadeout() {
+    document.querySelector('.preloader').style.opacity = '0';
+    document.querySelector('.preloader').style.display = 'none';
+  }
+</script>
+</body>
+
+</html>

--- a/src/main/resources/templates/order/checkout.html
+++ b/src/main/resources/templates/order/checkout.html
@@ -936,6 +936,7 @@
     })
     .catch(error => {
       console.error('주문 생성 및 결제 요청 중 오류 발생:', error);
+      window.location.href='/orders/fail'
     });
   }
 


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 주문 실패 시, 에러 페이지를 호출합니다.
- 인증 필터는 잠시 주석으로 처리하였습니다.
- FeignClient 예외 발생 시, `ControllerAdvice`로 처리하였습니다. 현재 404 페이지로 포워딩합니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [x] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->

<img width="1496" alt="image" src="https://github.com/nhnacademy-be6-yes-25-5/yes-25-5-front-server/assets/105257665/acc7955a-dc66-437d-9b0a-d89eec2d0a53">
