### PR TITLE
[주문] - 비회원 주문 내역 및 배송 조회 기능 구현

### DIFF
--- a/src/main/java/com/nhnacademy/frontserver1/application/service/OrderService.java
+++ b/src/main/java/com/nhnacademy/frontserver1/application/service/OrderService.java
@@ -2,6 +2,7 @@ package com.nhnacademy.frontserver1.application.service;
 
 import com.nhnacademy.frontserver1.presentation.dto.request.order.CreateOrderRequest;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.ReadCartBookResponse;
+import com.nhnacademy.frontserver1.presentation.dto.request.order.ReadOrderNoneMemberRequest;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.UpdateOrderRequest;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.CreateOrderResponse;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadMaximumDiscountCouponResponse;
@@ -48,4 +49,6 @@ public interface OrderService {
     ReadOrderDeliveryInfoResponse getMyOrderDelivery(String orderId);
 
     ReadOrderDetailResponse getMyOrderByOrderId(String orderId);
+
+    ReadOrderDetailResponse findOrderNoneMemberByOrderIdAndEmail(ReadOrderNoneMemberRequest request);
 }

--- a/src/main/java/com/nhnacademy/frontserver1/application/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/nhnacademy/frontserver1/application/service/impl/OrderServiceImpl.java
@@ -10,6 +10,7 @@ import com.nhnacademy.frontserver1.infrastructure.adaptor.PolicyAdaptor;
 import com.nhnacademy.frontserver1.infrastructure.adaptor.UserAdaptor;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.CreateOrderRequest;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.ReadCartBookResponse;
+import com.nhnacademy.frontserver1.presentation.dto.request.order.ReadOrderNoneMemberRequest;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.UpdateOrderRequest;
 import com.nhnacademy.frontserver1.presentation.dto.response.book.BookResponse;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.CreateOrderResponse;
@@ -24,7 +25,6 @@ import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadPurePrice
 import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadShippingPolicyResponse;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadTakeoutResponse;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.UpdateOrderResponse;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -132,5 +132,10 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public ReadOrderDetailResponse getMyOrderByOrderId(String orderId) {
         return orderAdaptor.getMyOrderByOrderId(orderId);
+    }
+
+    @Override
+    public ReadOrderDetailResponse findOrderNoneMemberByOrderIdAndEmail(ReadOrderNoneMemberRequest request) {
+        return orderAdaptor.findOrderNoneMemberByOrderIdAndEmail(request.orderId(), request.email());
     }
 }

--- a/src/main/java/com/nhnacademy/frontserver1/common/interceptor/JwtAuthorizationRequestInterceptor.java
+++ b/src/main/java/com/nhnacademy/frontserver1/common/interceptor/JwtAuthorizationRequestInterceptor.java
@@ -39,7 +39,7 @@ public class JwtAuthorizationRequestInterceptor implements RequestInterceptor {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
         String path = request.getServletPath();
 
-        if (path.startsWith("/auth/login")) {
+        if (path.startsWith("/auth/login") || path.startsWith("/orders/none") || path.matches(".*/orders/.*/delivery.*")) {
             return;
         }
 

--- a/src/main/java/com/nhnacademy/frontserver1/infrastructure/adaptor/OrderAdaptor.java
+++ b/src/main/java/com/nhnacademy/frontserver1/infrastructure/adaptor/OrderAdaptor.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "orderAdaptor", url = "${eureka.gateway}/orders", configuration = FeignClientConfig.class)
 public interface OrderAdaptor {
@@ -40,4 +41,7 @@ public interface OrderAdaptor {
 
     @GetMapping("/{orderId}")
     ReadOrderDetailResponse getMyOrderByOrderId(@PathVariable String orderId);
+
+    @GetMapping("/none/{orderId}")
+    ReadOrderDetailResponse findOrderNoneMemberByOrderIdAndEmail(@PathVariable String orderId, @RequestParam String email);
 }

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/controller/OrderController.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/controller/OrderController.java
@@ -4,6 +4,7 @@ import com.nhnacademy.frontserver1.application.service.OrderService;
 import com.nhnacademy.frontserver1.domain.TakeoutType;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.CreateOrderRequest;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.ReadCartBookResponse;
+import com.nhnacademy.frontserver1.presentation.dto.request.order.ReadOrderNoneMemberRequest;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.UpdateOrderRequest;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.CreateOrderResponse;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadOrderDeliveryInfoResponse;
@@ -25,6 +26,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -153,4 +155,17 @@ public class OrderController {
         return "mypage/mypage-delivery-detail";
     }
 
+    @GetMapping("/find")
+    public String getOrderFindPage() {
+        return "order/orders-find";
+    }
+
+    @GetMapping("/none")
+    public String getOrderNoneMember(@ModelAttribute ReadOrderNoneMemberRequest request, Model model) {
+        ReadOrderDetailResponse response = orderService.findOrderNoneMemberByOrderIdAndEmail(request);
+        model.addAttribute("order", response);
+        model.addAttribute("noneMember", "noneMember");
+
+        return "mypage/mypage-orders-detail";
+    }
 }

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/dto/request/order/ReadOrderNoneMemberRequest.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/dto/request/order/ReadOrderNoneMemberRequest.java
@@ -1,0 +1,5 @@
+package com.nhnacademy.frontserver1.presentation.dto.request.order;
+
+public record ReadOrderNoneMemberRequest(String orderId, String email) {
+
+}

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/dto/response/order/ReadOrderDetailResponse.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/dto/response/order/ReadOrderDetailResponse.java
@@ -29,6 +29,7 @@ public record ReadOrderDetailResponse(String orderId,
                                       Long couponId,
                                       BigDecimal points,
                                       List<String> bookNames,
-                                      List<Integer> quantities) {
+                                      List<Integer> quantities,
+                                      List<BigDecimal> bookPrices) {
 
 }

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -17,6 +17,9 @@
                             <li>
                                 <a href="#">Register</a>
                             </li>
+                            <li>
+                                <a href="/orders/find">주문번호로 주문내역 찾기</a>
+                            </li>
                         </ul>
                     </div>
                 </div>

--- a/src/main/resources/templates/mypage/mypage-delivery-detail.html
+++ b/src/main/resources/templates/mypage/mypage-delivery-detail.html
@@ -30,14 +30,14 @@
                     th:text="${#temporals.format(orderInfo.timestamp[orderInfo.timestamp.size() - 1], 'yyyy-MM-dd')}"></span>
               도착 완료
             </span>
-            <span th:if="${orderInfo.orderStatusType.name == 'WAIT'}">출고대기중</span>
-            <span th:if="${orderInfo.orderStatusType.name == 'DELIVERY'}">배송중</span>
+            <span th:if="${orderInfo.orderStatusType.name == 'WAIT'}">출고대기경중</span>
+            <span th:if="${orderInfo.orderStatusType.name == 'DELIVERING'}">배송중</span>
             <span th:if="${orderInfo.orderStatusType.name == 'DONE'}">배송완료</span>
           </h2>
           <p class="text-center">
             <span th:if="${orderInfo.orderStatusType.name == 'WAIT'}">고객님이 주문하신 상품이 출고대기중입니다.</span>
-            <span th:if="${orderInfo.orderStatusType.name == 'DELIVERY'}">고객님이 주문하신 상품을 안전하게 배송중입니다.</span>
-            <span th:if="${orderInfo.orderStatusType.name == 'DONE' or (orderInfo.orderStatusType.name != 'WAIT' and orderInfo.orderStatusType.name != 'DELIVERY')}">고객님이 주문하신 상품이 배송완료 되었습니다.</span>
+            <span th:if="${orderInfo.orderStatusType.name == 'DELIVERING'}">고객님이 주문하신 상품을 안전하게 배송중입니다.</span>
+            <span th:if="${orderInfo.orderStatusType.name == 'DONE' or (orderInfo.orderStatusType.name != 'WAIT' and orderInfo.orderStatusType.name != 'DELIVERING')}">고객님이 주문하신 상품이 배송완료 되었습니다.</span>
           </p>
           <div class="row">
             <div class="col-md-4 text-center">

--- a/src/main/resources/templates/mypage/mypage-delivery-detail.html
+++ b/src/main/resources/templates/mypage/mypage-delivery-detail.html
@@ -24,15 +24,14 @@
         <div class="card-body">
           <h2 class="card-title text-center">
             <span th:if="${orderInfo.orderStatusType.name == 'DONE'}">
-              <span th:if="${#temporals.isToday(orderInfo.timestamp[orderInfo.timestamp.size() - 1])}">오늘</span>
-              <span th:if="${#temporals.isYesterday(orderInfo.timestamp[orderInfo.timestamp.size() - 1])}">어제</span>
-              <span th:if="${#temporals.isToday(orderInfo.timestamp[orderInfo.timestamp.size() - 1]) == false and #temporals.isYesterday(orderInfo.timestamp[orderInfo.timestamp.size() - 1]) == false}"
-                    th:text="${#temporals.format(orderInfo.timestamp[orderInfo.timestamp.size() - 1], 'yyyy-MM-dd')}"></span>
+              <span th:if="${orderInfo.timestamp.get(orderInfo.timestamp.size() - 1).toLocalDate().isEqual(T(java.time.LocalDate).now())}">오늘</span>
+              <span th:if="${orderInfo.timestamp.get(orderInfo.timestamp.size() - 1).toLocalDate().isEqual(T(java.time.LocalDate).now().minusDays(1))}">어제</span>
+              <span th:if="${!orderInfo.timestamp.get(orderInfo.timestamp.size() - 1).toLocalDate().isEqual(T(java.time.LocalDate).now()) && !orderInfo.timestamp.get(orderInfo.timestamp.size() - 1).toLocalDate().isEqual(T(java.time.LocalDate).now().minusDays(1))}"
+                    th:text="${#dates.format(orderInfo.timestamp.get(orderInfo.timestamp.size() - 1), 'yyyy-MM-dd')}"></span>
               도착 완료
             </span>
             <span th:if="${orderInfo.orderStatusType.name == 'WAIT'}">출고대기중</span>
             <span th:if="${orderInfo.orderStatusType.name == 'DELIVERING'}">배송중</span>
-            <span th:if="${orderInfo.orderStatusType.name == 'DONE'}">배송완료</span>
           </h2>
           <p class="text-center">
             <span th:if="${orderInfo.orderStatusType.name == 'WAIT'}">고객님이 주문하신 상품이 출고대기중입니다.</span>

--- a/src/main/resources/templates/mypage/mypage-delivery-detail.html
+++ b/src/main/resources/templates/mypage/mypage-delivery-detail.html
@@ -30,14 +30,14 @@
                     th:text="${#temporals.format(orderInfo.timestamp[orderInfo.timestamp.size() - 1], 'yyyy-MM-dd')}"></span>
               도착 완료
             </span>
-            <span th:if="${orderInfo.orderStatusType.name == 'WAIT'}">출고대기경중</span>
+            <span th:if="${orderInfo.orderStatusType.name == 'WAIT'}">출고대기중</span>
             <span th:if="${orderInfo.orderStatusType.name == 'DELIVERING'}">배송중</span>
             <span th:if="${orderInfo.orderStatusType.name == 'DONE'}">배송완료</span>
           </h2>
           <p class="text-center">
             <span th:if="${orderInfo.orderStatusType.name == 'WAIT'}">고객님이 주문하신 상품이 출고대기중입니다.</span>
             <span th:if="${orderInfo.orderStatusType.name == 'DELIVERING'}">고객님이 주문하신 상품을 안전하게 배송중입니다.</span>
-            <span th:if="${orderInfo.orderStatusType.name == 'DONE' or (orderInfo.orderStatusType.name != 'WAIT' and orderInfo.orderStatusType.name != 'DELIVERING')}">고객님이 주문하신 상품이 배송완료 되었습니다.</span>
+            <span th:if="${orderInfo.orderStatusType.name == 'DONE'}">고객님이 주문하신 상품이 배송완료 되었습니다.</span>
           </p>
           <div class="row">
             <div class="col-md-4 text-center">

--- a/src/main/resources/templates/mypage/mypage-orders-detail.html
+++ b/src/main/resources/templates/mypage/mypage-orders-detail.html
@@ -1,36 +1,58 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout :: layout(~{::content})}">
 <head>
-  <title>Order Details</title>
+  <title>주문 상세</title>
   <link rel="stylesheet" th:href="@{/css/bootstrap.min.css}">
   <link rel="stylesheet" th:href="@{/css/styles.css}">
+  <style>
+    .order-details {
+      background-color: #f8f9fa;
+      border-radius: 8px;
+      padding: 20px;
+    }
+    .order-info {
+      background-color: #ffffff;
+      border: 1px solid #dee2e6;
+      border-radius: 8px;
+      padding: 15px;
+      margin-bottom: 20px;
+    }
+    .order-info p {
+      margin: 0;
+    }
+    .card-title span {
+      font-size: 1.2rem;
+      font-weight: bold;
+    }
+    .btn-custom {
+      margin-right: 10px;
+    }
+  </style>
 </head>
 <body>
 <div th:fragment="content" class="container mt-5">
-  <!-- Start Breadcrumbs Component -->
-<!--  <div th:replace="~{fragments/breadcrumbs :: breadcrumbs}"></div>-->
-  <!-- End Breadcrumbs Component -->
-
   <div class="row">
     <div class="col-md-3">
-      <!-- Include User Sidebar -->
       <div th:replace="~{fragments/user-sidebar :: user-sidebar}"></div>
     </div>
     <div class="col-md-9 order-details">
       <input type="hidden" id="orderId" th:value="${order.orderId}">
-      <h2>주문상세</h2>
+      <h2>주문 상세</h2>
       <div>
         <p><strong><span th:text="${#temporals.format(order.orderCreatedAt, 'yyyy. M. d')}"></span> 주문</strong> : 주문번호 <span th:text="${order.orderId}">11100055733606</span></p>
       </div>
-      <div class="card mb-4 order-card">
+      <div class="card mb-4 order-info">
         <div class="card-body">
-          <h5 class="card-title">
-            <span th:text="${#temporals.format(order.deliveryStartedAt, 'E')}"></span>
-          </h5>
           <div class="order-info">
-            <span th:text="${order.bookNames.get(0)}">와이넷 미니 세탁기용 배수호스</span>, <span th:text="${order.quantities.get(0)}">1개</span>
-            <br>
-            <strong th:text="${order.orderTotalAmount}">5,010원</strong>
+            <ul>
+              <li th:each="book, iterStat : ${order.bookNames}">
+                <p>
+                  <strong>물품 이름:</strong> <span th:text="${book}">도서 이름</span><br>
+                  <strong>개수:</strong> <span th:text="${order.quantities.get(iterStat.index)}">개수</span><br>
+                  <strong>가격:</strong> <span th:text="${order.bookPrices.get(iterStat.index)}">가격</span>
+                </p>
+              </li>
+            </ul>
           </div>
           <div class="btn-group">
             <button class="btn btn-secondary btn-custom" th:data-order-id="${order.orderId}" onclick="location.href='/orders/' + this.getAttribute('data-order-id') + '/delivery'">배송조회</button>
@@ -42,7 +64,7 @@
       </div>
       <div>
         <h5>받는사람 정보</h5>
-        <div class="card mb-4 order-card">
+        <div class="card mb-4 order-info">
           <div class="card-body">
             <p>
               받는사람: <span th:text="${order.receiveUserName}">김토스</span><br>
@@ -54,7 +76,7 @@
       </div>
       <div>
         <h5>결제 정보</h5>
-        <div class="card mb-4 order-card">
+        <div class="card mb-4 order-info">
           <div class="card-body">
             <p>
               총 상품가격: <span th:text="${order.orderTotalAmount}">5,010 원</span><br>
@@ -69,7 +91,6 @@
       </div>
     </div>
   </div>
-
   <script>
     function changeOrderStatus(status) {
       const orderId = document.getElementById('orderId').value;

--- a/src/main/resources/templates/mypage/mypage-orders-detail.html
+++ b/src/main/resources/templates/mypage/mypage-orders-detail.html
@@ -35,8 +35,8 @@
           <div class="btn-group">
             <button class="btn btn-secondary btn-custom" th:data-order-id="${order.orderId}" onclick="location.href='/orders/' + this.getAttribute('data-order-id') + '/delivery'">배송조회</button>
             <button class="btn btn-outline-secondary btn-custom">리뷰 작성하기</button>
-            <button class="btn btn-warning btn-custom" th:if="${order.orderStatusType.name == 'DONE'}" onclick="changeOrderStatus('REFUND')">반품</button>
-            <button class="btn btn-danger btn-custom" th:if="${order.orderStatusType.name == 'WAIT'}" onclick="changeOrderStatus('CANCEL')">결제취소</button>
+            <button class="btn btn-warning btn-custom" th:if="${order.orderStatusType.name == 'DONE'}" th:disabled="${noneMember != null}" onclick="changeOrderStatus('REFUND')">반품</button>
+            <button class="btn btn-danger btn-custom" th:if="${order.orderStatusType.name == 'WAIT'}" th:disabled="${noneMember != null}" onclick="changeOrderStatus('CANCEL')">결제취소</button>
           </div>
         </div>
       </div>
@@ -65,7 +65,7 @@
         </div>
       </div>
       <div class="text-center mt-4">
-        <a href="/mypage/orders" class="btn btn-primary">주문목록 돌아가기</a>
+        <a href="/mypage/orders" class="btn btn-primary" th:disabled="${noneMember != null}">주문목록 돌아가기</a>
       </div>
     </div>
   </div>

--- a/src/main/resources/templates/order/orders-find.html
+++ b/src/main/resources/templates/order/orders-find.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout :: layout(~{::content})}">
+<head>
+  <meta charset="UTF-8">
+  <title>비회원 주문내역 조회</title>
+  <link rel="stylesheet" th:href="@{/css/bootstrap.min.css}">
+  <link rel="stylesheet" th:href="@{/css/styles.css}">
+  <script th:src="@{/js/jquery.min.js}"></script>
+  <script th:src="@{/js/bootstrap.bundle.min.js}"></script>
+  <style>
+    body {
+      padding-top: 50px;
+    }
+    .container {
+      max-width: 800px;
+    }
+    .btn {
+      background-color: #f00;
+      color: #fff;
+    }
+    .form-control {
+      height: 45px;
+    }
+  </style>
+</head>
+<body>
+<div th:fragment="content" class="container mt-5">
+  <!-- Start Breadcrumbs Component -->
+  <div th:replace="~{fragments/breadcrumbs :: breadcrumbs}"></div>
+  <!-- End Breadcrumbs Component -->
+
+  <h2 class="text-center mb-4">비회원 주문/배송 조회</h2>
+  <ul class="nav nav-tabs" id="orderTabs" role="tablist">
+    <li class="nav-item">
+      <a class="nav-link active" id="orders-history-tab" data-bs-toggle="tab" href="#orders" role="tab" aria-controls="orders" aria-selected="true">주문 조회</a>
+    </li>
+  </ul>
+  <div class="tab-content" id="orderTabsContent">
+    <div class="tab-pane fade show active" id="orders" role="tabpanel" aria-labelledby="orders-history-tab">
+      <form action="/orders/none" method="get">
+        <div class="form-group">
+          <label for="orderId">주문번호</label>
+          <input type="text" class="form-control" id="orderId" name="orderId" placeholder="주문번호를 입력하세요" required>
+        </div>
+        <div class="form-group">
+          <label for="orderEmail">이메일</label>
+          <input type="email" class="form-control" id="orderEmail" name="email" placeholder="이메일을 입력하세요" required>
+        </div>
+        <button type="submit" class="btn btn-block">확인</button>
+      </form>
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 비회원 주문 내역 및 배송 조회 기능 구현하였습니다.
- 헤더에 `주문번호로 주문내역 찾기` 추가하여 해당 버튼 누르면 찾을 수 있도록 하였습니다.
- 필터에 비회원 주문 내역 찾기, 배송 찾기의 경우 jwt 필터를 거치지 않도록 변경하였습니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [x] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->