### PR TITLE
[마이페이지] - 포인트 및 등급 조회 api를 가져오기 위한 인터셉터 추가

### DIFF
--- a/src/main/java/com/nhnacademy/frontserver1/application/service/OrderService.java
+++ b/src/main/java/com/nhnacademy/frontserver1/application/service/OrderService.java
@@ -1,7 +1,7 @@
 package com.nhnacademy.frontserver1.application.service;
 
 import com.nhnacademy.frontserver1.presentation.dto.request.order.CreateOrderRequest;
-import com.nhnacademy.frontserver1.presentation.dto.request.order.ReadCartBookResponse;
+import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadCartBookResponse;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.ReadOrderNoneMemberRequest;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.UpdateOrderRequest;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.CreateOrderResponse;

--- a/src/main/java/com/nhnacademy/frontserver1/application/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/nhnacademy/frontserver1/application/service/impl/OrderServiceImpl.java
@@ -9,7 +9,7 @@ import com.nhnacademy.frontserver1.infrastructure.adaptor.OrderAdaptor;
 import com.nhnacademy.frontserver1.infrastructure.adaptor.PolicyAdaptor;
 import com.nhnacademy.frontserver1.infrastructure.adaptor.UserAdaptor;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.CreateOrderRequest;
-import com.nhnacademy.frontserver1.presentation.dto.request.order.ReadCartBookResponse;
+import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadCartBookResponse;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.ReadOrderNoneMemberRequest;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.UpdateOrderRequest;
 import com.nhnacademy.frontserver1.presentation.dto.response.book.BookResponse;

--- a/src/main/java/com/nhnacademy/frontserver1/application/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/nhnacademy/frontserver1/application/service/impl/UserServiceImpl.java
@@ -23,9 +23,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public ReadUserInfoResponse getUserPointsAndGrade() {
-//        return userAdaptor.getUserPointsAndGrade();
-
-        return ReadUserInfoResponse.fromTest();
+        return userAdaptor.getUserPointsAndGrade();
     }
 
     // fixme. 해당 기능 구현하지 않아 주석처리하였습니다.

--- a/src/main/java/com/nhnacademy/frontserver1/common/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/nhnacademy/frontserver1/common/advice/GlobalControllerAdvice.java
@@ -4,9 +4,6 @@ import com.nhnacademy.frontserver1.application.service.UserService;
 import com.nhnacademy.frontserver1.common.exception.FeignClientException;
 import com.nhnacademy.frontserver1.common.exception.OrderWaitingException;
 import com.nhnacademy.frontserver1.common.exception.TokenCookieMissingException;
-import com.nhnacademy.frontserver1.presentation.dto.response.user.ReadUserInfoResponse;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -14,7 +11,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
@@ -46,10 +42,5 @@ public class GlobalControllerAdvice {
         log.warn("OrderWaitingException 발생: ", e);
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
             .body(e.getMessage());
-    }
-
-    @ModelAttribute("userInfo")
-    public ReadUserInfoResponse addUserInfo() {
-        return userService.getUserPointsAndGrade();
     }
 }

--- a/src/main/java/com/nhnacademy/frontserver1/common/config/WebConfig.java
+++ b/src/main/java/com/nhnacademy/frontserver1/common/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.nhnacademy.frontserver1.common.config;
+
+import com.nhnacademy.frontserver1.common.interceptor.UserInfoInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final UserInfoInterceptor userInfoInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(userInfoInterceptor)
+            .addPathPatterns("/mypage/**");
+    }
+}

--- a/src/main/java/com/nhnacademy/frontserver1/common/interceptor/UserInfoInterceptor.java
+++ b/src/main/java/com/nhnacademy/frontserver1/common/interceptor/UserInfoInterceptor.java
@@ -1,0 +1,28 @@
+package com.nhnacademy.frontserver1.common.interceptor;
+
+import com.nhnacademy.frontserver1.application.service.UserService;
+import com.nhnacademy.frontserver1.presentation.dto.response.user.ReadUserInfoResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+@Component
+@RequiredArgsConstructor
+public class UserInfoInterceptor implements HandlerInterceptor {
+
+    private final ApplicationContext applicationContext;
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+        ModelAndView modelAndView) throws Exception {
+        if (modelAndView != null) {
+            UserService userService = applicationContext.getBean(UserService.class);
+            ReadUserInfoResponse userInfo = userService.getUserPointsAndGrade();
+            modelAndView.addObject("userInfo", userInfo);
+        }
+    }
+}

--- a/src/main/java/com/nhnacademy/frontserver1/infrastructure/adaptor/CartAdaptor.java
+++ b/src/main/java/com/nhnacademy/frontserver1/infrastructure/adaptor/CartAdaptor.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.frontserver1.infrastructure.adaptor;
 
-import com.nhnacademy.frontserver1.presentation.dto.request.order.ReadCartBookResponse;
+import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadCartBookResponse;
 import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/controller/OrderController.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/controller/OrderController.java
@@ -3,11 +3,10 @@ package com.nhnacademy.frontserver1.presentation.controller;
 import com.nhnacademy.frontserver1.application.service.OrderService;
 import com.nhnacademy.frontserver1.domain.TakeoutType;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.CreateOrderRequest;
-import com.nhnacademy.frontserver1.presentation.dto.request.order.ReadCartBookResponse;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.ReadOrderNoneMemberRequest;
 import com.nhnacademy.frontserver1.presentation.dto.request.order.UpdateOrderRequest;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.CreateOrderResponse;
-import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadOrderDeliveryInfoResponse;
+import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadCartBookResponse;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadOrderDetailResponse;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadOrderStatusResponse;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadOrderUserAddressResponse;
@@ -137,22 +136,6 @@ public class OrderController {
     public ResponseEntity<UpdateOrderResponse> updateOrder(@PathVariable String orderId,
         @RequestBody UpdateOrderRequest request) {
         return ResponseEntity.ok(orderService.updateOrderByOrderId(orderId, request));
-    }
-
-    @GetMapping("/{orderId}")
-    public String getOrder(@PathVariable String orderId, Model model) {
-        ReadOrderDetailResponse response = orderService.getMyOrderByOrderId(orderId);
-        model.addAttribute("order", response);
-
-        return "mypage/mypage-orders-detail";
-    }
-
-    @GetMapping("/{orderId}/delivery")
-    public String getOrderDelivery(@PathVariable String orderId, Model model) {
-        ReadOrderDeliveryInfoResponse orderInfoResponse = orderService.getMyOrderDelivery(orderId);
-        model.addAttribute("orderInfo", orderInfoResponse);
-
-        return "mypage/mypage-delivery-detail";
     }
 
     @GetMapping("/find")

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/controller/OrderHistoryController.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/controller/OrderHistoryController.java
@@ -2,6 +2,8 @@ package com.nhnacademy.frontserver1.presentation.controller;
 
 import com.nhnacademy.frontserver1.application.service.OrderService;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadMyOrderHistoryResponse;
+import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadOrderDeliveryInfoResponse;
+import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadOrderDetailResponse;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadPurePriceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -9,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -27,5 +30,21 @@ public class OrderHistoryController {
         model.addAttribute("orders", readMyOrderHistoryResponses);
 
         return "mypage/mypage-orders-history";
+    }
+
+    @GetMapping("/orders/{orderId}")
+    public String getOrder(@PathVariable String orderId, Model model) {
+        ReadOrderDetailResponse response = orderService.getMyOrderByOrderId(orderId);
+        model.addAttribute("order", response);
+
+        return "mypage/mypage-orders-detail";
+    }
+
+    @GetMapping("/orders/{orderId}/delivery")
+    public String getOrderDelivery(@PathVariable String orderId, Model model) {
+        ReadOrderDeliveryInfoResponse orderInfoResponse = orderService.getMyOrderDelivery(orderId);
+        model.addAttribute("orderInfo", orderInfoResponse);
+
+        return "mypage/mypage-delivery-detail";
     }
 }

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/dto/response/order/ReadCartBookResponse.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/dto/response/order/ReadCartBookResponse.java
@@ -1,4 +1,4 @@
-package com.nhnacademy.frontserver1.presentation.dto.request.order;
+package com.nhnacademy.frontserver1.presentation.dto.response.order;
 
 import com.nhnacademy.frontserver1.presentation.dto.response.book.BookResponse;
 import java.math.BigDecimal;

--- a/src/main/resources/templates/mypage/mypage-orders-history.html
+++ b/src/main/resources/templates/mypage/mypage-orders-history.html
@@ -86,7 +86,7 @@
                                             </thead>
                                             <tbody>
                                             <tr th:each="order : ${orders.content}">
-                                                <td><a th:href="@{/orders/{orderId}(orderId=${order.orderId})}" th:text="${order.orderId}">1234567890</a></td>
+                                                <td><a th:href="@{/mypage/orders/{orderId}(orderId=${order.orderId})}" th:text="${order.orderId}">1234567890</a></td>
                                                 <td th:text="${#temporals.format(order.orderCreatedAt, 'yyyy-MM-dd')}">2023-06-10</td>
                                                 <td>
                                                     <span th:text="${order.bookNames.get(0)}">Product 1</span>
@@ -96,7 +96,7 @@
                                                 <td th:text="${order.orderTotalAmount}">$99.99</td>
                                                 <td th:text="#{${'order.status.' + order.orderStatus}}">출고처리중</td>
                                                 <td>
-                                                    <a th:href="@{/orders/{orderId}/delivery(orderId=${order.orderId})}" class="btn btn-sm btn-primary">배송 조회</a>
+                                                    <a th:href="@{/mypage/orders/{orderId}/delivery(orderId=${order.orderId})}" class="btn btn-sm btn-primary">배송 조회</a>
                                                 </td>
                                             </tr>
                                             </tbody>


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 포인트 및 등급 조회 api를 가져오기 위해 인터셉터 추가하였습니다.
- 기존에는 `ControllerAdvice`에 있었으나 해당 위치에 있으면 모든 컨트롤러에서 동작하기 때문에 로그인을 안하더라도 동작하게 됩니다.
- 따라서, `mypage`로 시작할때만 포인트와 등급을 조회하는 인터셉터를 구현하였습니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [x] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->