### PR TITLE
[결제] - 결제창을 닫아도 다시 결제를 이어서 할 수 있도록 수정

### DIFF
--- a/src/main/java/com/nhnacademy/frontserver1/application/service/CartService.java
+++ b/src/main/java/com/nhnacademy/frontserver1/application/service/CartService.java
@@ -17,4 +17,6 @@ public interface CartService {
     UpdateCartBookResponse updateCart(String cartId, Long bookId, UpdateCartBookRequest request);
 
     DeleteCartBookResponse deleteCartBook(String cartId, Long bookId);
+
+    List<ReadCartBookResponse> getCartsWithOrder(String cartId);
 }

--- a/src/main/java/com/nhnacademy/frontserver1/application/service/impl/CartServiceImpl.java
+++ b/src/main/java/com/nhnacademy/frontserver1/application/service/impl/CartServiceImpl.java
@@ -1,6 +1,8 @@
 package com.nhnacademy.frontserver1.application.service.impl;
 
 import com.nhnacademy.frontserver1.application.service.CartService;
+import com.nhnacademy.frontserver1.common.exception.ApplicationException;
+import com.nhnacademy.frontserver1.common.exception.payload.ErrorStatus;
 import com.nhnacademy.frontserver1.infrastructure.adaptor.CartAdaptor;
 import com.nhnacademy.frontserver1.presentation.dto.request.cart.CreateCartRequest;
 import com.nhnacademy.frontserver1.presentation.dto.request.cart.UpdateCartBookRequest;
@@ -8,11 +10,13 @@ import com.nhnacademy.frontserver1.presentation.dto.response.cart.CreateCartResp
 import com.nhnacademy.frontserver1.presentation.dto.response.cart.DeleteCartBookResponse;
 import com.nhnacademy.frontserver1.presentation.dto.response.cart.UpdateCartBookResponse;
 import com.nhnacademy.frontserver1.presentation.dto.response.order.ReadCartBookResponse;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -42,5 +46,16 @@ public class CartServiceImpl implements CartService {
     @Override
     public DeleteCartBookResponse deleteCartBook(String cartId, Long bookId) {
         return cartAdaptor.deleteCartBookByBookId(cartId, bookId);
+    }
+
+    @Override
+    public List<ReadCartBookResponse> getCartsWithOrder(String cartId) {
+        List<ReadCartBookResponse> responses = getCarts(cartId);
+        if (CollectionUtils.isEmpty(responses)) {
+            throw new ApplicationException(ErrorStatus.toErrorStatus(
+                "주문할 도서가 존재하지 없습니다.", 404, LocalDateTime.now()));
+        }
+
+        return responses;
     }
 }

--- a/src/main/java/com/nhnacademy/frontserver1/common/converter/StringToPaymentProviderConverter.java
+++ b/src/main/java/com/nhnacademy/frontserver1/common/converter/StringToPaymentProviderConverter.java
@@ -1,0 +1,15 @@
+package com.nhnacademy.frontserver1.common.converter;
+
+
+import com.nhnacademy.frontserver1.domain.PaymentProvider;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToPaymentProviderConverter implements Converter<String, PaymentProvider> {
+
+    @Override
+    public PaymentProvider convert(String source) {
+        return PaymentProvider.from(source);
+    }
+}

--- a/src/main/java/com/nhnacademy/frontserver1/common/decoder/CustomErrorDecoder.java
+++ b/src/main/java/com/nhnacademy/frontserver1/common/decoder/CustomErrorDecoder.java
@@ -1,6 +1,15 @@
 package com.nhnacademy.frontserver1.common.decoder;
 
-import com.nhnacademy.frontserver1.common.exception.*;
+import com.nhnacademy.frontserver1.common.exception.BookException;
+import com.nhnacademy.frontserver1.common.exception.ConnectionException;
+import com.nhnacademy.frontserver1.common.exception.DormantAccountException;
+import com.nhnacademy.frontserver1.common.exception.ExpireRefreshJwtException;
+import com.nhnacademy.frontserver1.common.exception.FeignClientException;
+import com.nhnacademy.frontserver1.common.exception.LikesNotLoginException;
+import com.nhnacademy.frontserver1.common.exception.LoginException;
+import com.nhnacademy.frontserver1.common.exception.OrderWaitingException;
+import com.nhnacademy.frontserver1.common.exception.RefreshTokenFailedException;
+import com.nhnacademy.frontserver1.common.exception.UnauthorizedAccessException;
 import com.nhnacademy.frontserver1.common.exception.payload.ErrorStatus;
 import feign.Response;
 import feign.codec.ErrorDecoder;

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/controller/OrderController.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/controller/OrderController.java
@@ -52,7 +52,7 @@ public class OrderController {
     public String findAllCheckout(Model model, Pageable pageable, HttpServletRequest request) {
         String cartId = getCartIdFromCookie(request);
         String orderId = UUID.randomUUID().toString();
-        List<ReadCartBookResponse> cartBookResponses = cartService.getCarts(cartId);
+        List<ReadCartBookResponse> cartBookResponses = cartService.getCartsWithOrder(cartId);
         ReadOrderUserInfoResponse orderUserInfoResponse = orderService.getUserInfo(request);
         Integer totalAmount = getTotalAmount(cartBookResponses);
 

--- a/src/main/java/com/nhnacademy/frontserver1/presentation/controller/PaymentController.java
+++ b/src/main/java/com/nhnacademy/frontserver1/presentation/controller/PaymentController.java
@@ -19,11 +19,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Controller
 @RequestMapping("/payments")

--- a/src/main/resources/static/js/TossPaymentService.js
+++ b/src/main/resources/static/js/TossPaymentService.js
@@ -13,13 +13,12 @@ class TossPaymentService extends PaymentService {
       orderId: orderId,
       orderName: orderId,
       customerName: customerKey,
-      paymentProvider : paymentProvider,
       successUrl: window.location.origin + "/payments/success?paymentProvider=" + paymentProvider,
       failUrl: window.location.origin + "/payments/fail",
     });
   }
 
-  confirmPayment(paymentKey, orderId, amount) {
+confirmPayment(paymentKey, orderId, amount) {
     return fetch("/payments/confirm", {
       method: "POST",
       headers: {

--- a/src/main/resources/templates/order/checkout.html
+++ b/src/main/resources/templates/order/checkout.html
@@ -83,6 +83,37 @@
     .payment-option .switch i {
       margin-left: 10px;
     }
+
+    .loader-wrapper {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(255, 255, 255, 0.8);
+      z-index: 1000;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .loader {
+      border: 8px solid #f3f3f3;
+      border-radius: 50%;
+      border-top: 8px solid #3498db;
+      width: 60px;
+      height: 60px;
+      animation: spin 2s linear infinite;
+    }
+
+    @keyframes spin {
+      0% {
+        transform: rotate(0deg);
+      }
+      100% {
+        transform: rotate(360deg);
+      }
+    }
   </style>
 </head>
 
@@ -530,6 +561,9 @@
         </div>
       </div>
     </div>
+    <div class="loader-wrapper" id="loaderWrapper">
+      <div class="loader"></div>
+    </div>
   </div>
 </section>
 <!--====== Checkout Form Steps Part Ends ======-->
@@ -554,6 +588,15 @@
 <script src="/js/GeneralPaymentService.js"></script>
 <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
 <script>
+
+  function showLoader() {
+    document.getElementById('loaderWrapper').style.display = 'flex';
+  }
+
+  function hideLoader() {
+    document.getElementById('loaderWrapper').style.display = 'none';
+  }
+
   function setMinDeliveryDate() {
     const deliveryDateInput = document.getElementById('deliveryDate');
     const today = new Date();
@@ -750,10 +793,6 @@
         input => input.value
     ).filter(value => value !== "");
 
-    console.log(couponIds);
-
-    console.log('Collected couponIds:', couponIds);
-
     const orderData = {
       orderId: orderId,
       deliveryDate: deliveryDateValue,
@@ -782,8 +821,6 @@
       paymentProvider: paymentMethod
     };
 
-    console.log('orderData:', orderData);
-
     fetch('/orders', {
       method: 'POST',
       headers: {
@@ -793,26 +830,20 @@
     })
     .then(response => response.json())
     .then(data => {
-      const {orderId, totalAmount, paymentProvider} = data;
+      const { orderId, totalAmount, paymentProvider } = data;
       const paymentService = createPaymentService(paymentMethod);
       if (parseInt(totalAmount, 10) === 0) {
         completeZeroAmountPayment(orderData);
       } else {
-        paymentService.requestPayment({orderId, totalAmount, paymentProvider})
-        .catch(error => {
-          console.error('결제 요청 중 오류 발생:', error);
-          window.location.href = '/payments/fail';
-        });
+        paymentService.requestPayment({ orderId, totalAmount, paymentProvider });
       }
     })
     .catch(error => {
-      console.error('주문 생성 중 오류 발생:', error);
-      window.location.href = '/orders/fail';
+      alert('예상치 못한 에러가 발생했습니다. 다시 시도해주세요.');
     });
   }
 
   function completeZeroAmountPayment(orderData) {
-    console.log("completeZeroAmountPayment 호출됨");
     const paymentKey = generateUUID();
 
     const paymentData = {
@@ -837,13 +868,11 @@
         });
         window.location.href = `/payments/success?${urlParams.toString()}`;
       } else {
-        console.log("결제 완료 처리 실패");
-        window.location.href = '/payments/fail';
+        alert("결제 완료 처리 실패");
       }
     })
     .catch(error => {
-      console.error('결제 완료 처리 중 오류 발생:', error);
-      window.location.href = '/payments/fail';
+      alert('결제 완료 처리 중 오류 발생:', error);
     });
   }
 


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [ ] Feature
- [ ] Rename
- [x] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 기존의 경우, 토스 결제 요청 실패(paymentKey 발급 실패)할 경우 지정해둔 failUrl로 리디렉션됐습니다.
- 결제창을 닫아도 기존 페이지에서 다시 결제를 이어서 할 수 있도록 변경했습니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [x] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->