### PR TITLE
[주문] - 비회원 결제 확정 시, 토큰 확인하지 않도록 변경

### DIFF
--- a/src/main/java/com/nhnacademy/frontserver1/common/interceptor/FeignJwtTokenInterceptor.java
+++ b/src/main/java/com/nhnacademy/frontserver1/common/interceptor/FeignJwtTokenInterceptor.java
@@ -118,6 +118,7 @@ public class FeignJwtTokenInterceptor implements RequestInterceptor {
     private boolean isServletPathAndFeignExclude(String servletPath, String feignPath) {
         return (servletPath.equals("/") || servletPath.startsWith("/orders/none") || servletPath.startsWith("/category") || servletPath.startsWith("/search")
             || servletPath.startsWith("/sign-up") || servletPath.startsWith("/books") || servletPath.matches("/coupons") || servletPath.startsWith("/check-email")
+            || servletPath.startsWith("/orders/status")
             || servletPath.startsWith("/dormant")|| servletPath.startsWith("/users/sign-up") || servletPath.equals("/callback") || servletPath.startsWith("/users/find/password") || servletPath.startsWith("/carts") || servletPath.startsWith("/auth/login") || servletPath.startsWith("/users/find-email")
         || feignPath.startsWith("/cart-books") || feignPath.startsWith("/shipping") || feignPath.startsWith("/takeout")) || feignPath.startsWith("/sign-up") || feignPath.startsWith("/login");
     }

--- a/src/main/java/com/nhnacademy/frontserver1/common/interceptor/FeignJwtTokenInterceptor.java
+++ b/src/main/java/com/nhnacademy/frontserver1/common/interceptor/FeignJwtTokenInterceptor.java
@@ -118,7 +118,6 @@ public class FeignJwtTokenInterceptor implements RequestInterceptor {
     private boolean isServletPathAndFeignExclude(String servletPath, String feignPath) {
         return (servletPath.equals("/") || servletPath.startsWith("/orders/none") || servletPath.startsWith("/category") || servletPath.startsWith("/search")
             || servletPath.startsWith("/sign-up") || servletPath.startsWith("/books") || servletPath.matches("/coupons") || servletPath.startsWith("/check-email")
-            || servletPath.startsWith("/dormant")|| servletPath.startsWith("/users/sign-up") || servletPath.equals("/callback") || servletPath.startsWith("/users/find/password") || servletPath.startsWith("/carts") || servletPath.startsWith("/auth/login") || servletPath.startsWith("/find-email")
             || servletPath.startsWith("/orders/status")
             || servletPath.startsWith("/dormant")|| servletPath.startsWith("/users/sign-up") || servletPath.equals("/callback") || servletPath.startsWith("/users/find/password") || servletPath.startsWith("/carts") || servletPath.startsWith("/auth/login") || servletPath.startsWith("/users/find-email")
         || feignPath.startsWith("/cart-books") || feignPath.startsWith("/shipping") || feignPath.startsWith("/takeout")) || feignPath.startsWith("/sign-up") || feignPath.startsWith("/login");


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [x] Bugfix
- [ ] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 결제 확정 시, 주문이 완료됐는지 확인하는 코드가 있는데 토큰을 담아서 주문 서버에 요청을 보내려고 합니다. 이때, 비회원일 경우 정상적으로 요청이 가지 않아 문제가 발생했습니다.
- 비회원 결제 확정 시, 토큰 확인하지 않도록 변경했습니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [x] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->